### PR TITLE
Delete .github/CODEOWNERS.txt

### DIFF
--- a/.github/CODEOWNERS.txt
+++ b/.github/CODEOWNERS.txt
@@ -1,1 +1,0 @@
-* @microsoft/etw


### PR DESCRIPTION
Github only wants the one without a file extension