### PR TITLE
Specify type for DateTime variable to fix compilation error

### DIFF
--- a/src/native/etw.rs
+++ b/src/native/etw.rs
@@ -21,7 +21,7 @@ struct Win32SystemTime {
 
 impl From<std::time::SystemTime> for Win32SystemTime {
     fn from(value: std::time::SystemTime) -> Self {
-        let dt = chrono::DateTime::from(value);
+        let dt: chrono::DateTime<chrono::Utc> = chrono::DateTime::from(value);
 
         Win32SystemTime {
             st: [


### PR DESCRIPTION
Ran into type annotation compilation error when using crate because of unspecified time zone in datetime variable. Fixed by specifying the timezone.