### PR TITLE
Version increment for publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-etw"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 resolver = "2"
 license = "MIT"
@@ -39,7 +39,7 @@ tracing = {version = "0.1", default-features = false, features = ["std", "attrib
 tracing-subscriber = {version="0.3", default-features = false, features=["std", "fmt", "registry"]}
 
 [target.'cfg(windows)'.dev-dependencies]
-windows = {version="0.58", features=["Win32_System_Diagnostics_Etw", "Win32_Foundation", "Win32_System_Time"]}
+windows = {version="0.62", features=["Win32_System_Diagnostics_Etw", "Win32_Foundation", "Win32_System_Time"]}
 #etw_helpers = {version="0.1", path="../etw_helpers"}
 
 [[bench]]

--- a/src/layer/layer_impl.rs
+++ b/src/layer/layer_impl.rs
@@ -116,7 +116,7 @@ where
         let current_span = ctx
             .event_span(event)
             .map(|evt| evt.id())
-            .map_or(0, |id| (id.into_u64()));
+            .map_or(0, |id| id.into_u64());
         let parent_span = ctx
             .event_span(event)
             .map_or(0, |evt| evt.parent().map_or(0, |p| p.id().into_u64()));


### PR DESCRIPTION
Increment version number to publish 0.2.2.

This version picks up several build fixes, warning fixes for newer Rust versions, and big internal improvements to the use of generics. Fixes #25.