### PR TITLE
Fix unused code warnings on macos

### DIFF
--- a/src/values/event_values.rs
+++ b/src/values/event_values.rs
@@ -5,11 +5,13 @@ use tracing::field;
 use crate::values::*;
 
 // Implemented on the EventBuilder types
+#[allow(dead_code)]
 pub(crate) trait AddFieldAndValue {
     fn add_field_value(&mut self, fv: &crate::values::FieldAndValue);
 }
 
 // We need a wrapper because we cannot implement an external trait (field::Visit) on an external type (EventBuilder)
+#[allow(dead_code)]
 pub(crate) struct EventBuilderVisitorWrapper<T: AddFieldAndValue> {
     wrapped: T,
 }

--- a/src/values/mod.rs
+++ b/src/values/mod.rs
@@ -73,6 +73,7 @@ impl From<char> for ValueTypes {
     }
 }
 
+#[allow(dead_code)]
 pub(crate) struct FieldAndValue<'a> {
     #[allow(dead_code)]
     pub(crate) field_name: &'static str,


### PR DESCRIPTION
As a Tier 1 target for Rust, the crate should compile without warnings even though it is a no-op.