### PR TITLE
Adds support for OpenTelemetry TraceId/SpanId

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ crate-type = ["rlib"]
 
 [features]
 global_filter = []
+# Enable OpenTelemetry trace context extraction. When enabled, span_id and trace_id
+# will be extracted from tracing-opentelemetry's OtelData span extensions when available.
+opentelemetry = ["dep:tracing-opentelemetry", "dep:opentelemetry"]
 
 [dependencies]
 tracing = {version = "0.1", default-features = false}
@@ -24,6 +27,10 @@ paste = "1"
 thiserror = {version="2", default-features = false}
 hashers = "1"
 hashbrown = "0.15"
+
+# Optional OpenTelemetry dependencies
+tracing-opentelemetry = {version = "0.32", optional = true}
+opentelemetry = {version = "0.31", optional = true, default-features = false, features = ["trace"]}
 
 [target.'cfg(not(target_os = "linux"))'.dependencies]
 tracelogging = ">= 1.2.0"

--- a/src/layer/layer_impl.rs
+++ b/src/layer/layer_impl.rs
@@ -121,6 +121,20 @@ where
             .event_span(event)
             .map_or(0, |evt| evt.parent().map_or(0, |p| p.id().into_u64()));
 
+        // Extract OpenTelemetry context if available
+        #[cfg(feature = "opentelemetry")]
+        let otel_context = ctx.event_span(event).and_then(|span| {
+            let otel_ctx = crate::otel::extract_otel_context(&span);
+            if otel_ctx.is_valid {
+                Some((otel_ctx.trace_id, otel_ctx.span_id))
+            } else {
+                None
+            }
+        });
+
+        #[cfg(not(feature = "opentelemetry"))]
+        let otel_context: Option<([u8; 32], [u8; 16])> = None;
+
         let etw_meta = get_event_metadata(&event.metadata().callsite());
         let (name, keyword, tag) = if let Some(meta) = etw_meta {
             (event.metadata().name(), meta.kw, meta.event_tag)
@@ -137,6 +151,7 @@ where
             keyword,
             tag,
             event,
+            otel_context,
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,6 +195,11 @@ mod values;
 pub mod _details;
 pub mod error;
 
+// OpenTelemetry integration module - only available with the "opentelemetry" feature
+#[cfg(feature = "opentelemetry")]
+#[cfg_attr(docsrs, doc(cfg(feature = "opentelemetry")))]
+pub(crate) mod otel;
+
 pub use layer_builder::LayerBuilder;
 
 mod layer;

--- a/src/native/etw.rs
+++ b/src/native/etw.rs
@@ -5,9 +5,7 @@ use crate::{
     values::{event_values::*, *},
 };
 use chrono::{Datelike, Timelike};
-use std::io::{Cursor, Write};
 use std::marker::PhantomData;
-use std::mem::MaybeUninit;
 use std::{cell::RefCell, ops::DerefMut, pin::Pin, sync::Arc, time::SystemTime};
 use tracelogging::*;
 use tracelogging_dynamic::EventBuilder;
@@ -299,6 +297,7 @@ impl<Mode: OutputMode> super::EventWriter<NormalOutput> for Provider<Mode> {
         keyword: u64,
         event_tag: u32,
         event: &tracing::Event<'_>,
+        _otel_context: Option<([u8; 32], [u8; 16])>,
     ) {
         let mut activity_id: [u8; 16] = *GLOBAL_ACTIVITY_SEED;
         activity_id[0] = if current_span != 0 {
@@ -414,11 +413,33 @@ impl<Mode: OutputMode> super::EventWriter<CommonSchemaOutput> for Provider<Mode>
     {
         let span_name = span.name();
 
-        let span_id = unsafe {
-            let mut span_id = MaybeUninit::<[u8; 16]>::uninit();
-            let mut cur = Cursor::new((*span_id.as_mut_ptr()).as_mut_slice());
-            write!(&mut cur, "{:16x}", span.id().into_u64()).expect("!write");
-            span_id.assume_init()
+        // Extract trace_id and span_id - prefer OpenTelemetry context when available
+        #[cfg(feature = "opentelemetry")]
+        let (trace_id, span_id) = {
+            let otel_ctx = crate::otel::extract_otel_context(span);
+            if otel_ctx.is_valid {
+                (otel_ctx.trace_id, otel_ctx.span_id)
+            } else {
+                // Fall back to local tracing span ID
+                let mut span_id_buf = [0u8; 16];
+                let trace_id_buf = [0u8; 32];
+                let _ = std::io::Write::write_fmt(
+                    &mut span_id_buf.as_mut_slice(),
+                    format_args!("{:016x}", span.id().into_u64()),
+                );
+                (trace_id_buf, span_id_buf)
+            }
+        };
+
+        #[cfg(not(feature = "opentelemetry"))]
+        let (trace_id, span_id) = {
+            let mut span_id_buf = [0u8; 16];
+            let trace_id_buf = [0u8; 32];
+            let _ = std::io::Write::write_fmt(
+                &mut span_id_buf.as_mut_slice(),
+                format_args!("{:016x}", span.id().into_u64()),
+            );
+            (trace_id_buf, span_id_buf)
         };
 
         EBW.with(|eb| {
@@ -441,7 +462,7 @@ impl<Mode: OutputMode> super::EventWriter<CommonSchemaOutput> for Provider<Mode>
 
                 eb.add_struct("ext_dt", 2, 0);
                 {
-                    eb.add_str8("traceId", "", OutType::Utf8, 0); // TODO
+                    eb.add_str8("traceId", trace_id, OutType::Utf8, 0);
                     eb.add_str8("spanId", span_id, OutType::Utf8, 0);
                 }
             }
@@ -465,11 +486,30 @@ impl<Mode: OutputMode> super::EventWriter<CommonSchemaOutput> for Provider<Mode>
                 eb.add_str8("_typeName", "Span", OutType::Utf8, 0);
 
                 if let Some(parent) = span_parent {
-                    let parent_span_id = unsafe {
-                        let mut span_id = MaybeUninit::<[u8; 16]>::uninit();
-                        let mut cur = Cursor::new((*span_id.as_mut_ptr()).as_mut_slice());
-                        write!(&mut cur, "{:16x}", parent.id().into_u64()).expect("!write");
-                        span_id.assume_init()
+                    // Extract parent span_id - prefer OpenTelemetry context when available
+                    #[cfg(feature = "opentelemetry")]
+                    let parent_span_id = {
+                        let otel_ctx = crate::otel::extract_otel_context(&parent);
+                        if otel_ctx.is_valid {
+                            otel_ctx.span_id
+                        } else {
+                            let mut buf = [0u8; 16];
+                            let _ = std::io::Write::write_fmt(
+                                &mut buf.as_mut_slice(),
+                                format_args!("{:016x}", parent.id().into_u64()),
+                            );
+                            buf
+                        }
+                    };
+
+                    #[cfg(not(feature = "opentelemetry"))]
+                    let parent_span_id = {
+                        let mut buf = [0u8; 16];
+                        let _ = std::io::Write::write_fmt(
+                            &mut buf.as_mut_slice(),
+                            format_args!("{:016x}", parent.id().into_u64()),
+                        );
+                        buf
                     };
 
                     eb.add_str8("parentId", parent_span_id, OutType::Utf8, 0);
@@ -518,6 +558,7 @@ impl<Mode: OutputMode> super::EventWriter<CommonSchemaOutput> for Provider<Mode>
         keyword: u64,
         event_tag: u32,
         event: &tracing::Event<'_>,
+        otel_context: Option<([u8; 32], [u8; 16])>,
     ) {
         EBW.with(|eb| {
             let mut eb = eb.borrow_mut();
@@ -532,7 +573,7 @@ impl<Mode: OutputMode> super::EventWriter<CommonSchemaOutput> for Provider<Mode>
             eb.add_u16("__csver__", 0x0401, OutType::Signed, 0);
             eb.add_struct(
                 "PartA",
-                1 + if current_span != 0 { 1 } else { 0 }, /* + exts.len() as u8*/
+                1 + if current_span != 0 || otel_context.is_some() { 1 } else { 0 }, /* + exts.len() as u8*/
                 0,
             );
             {
@@ -540,18 +581,24 @@ impl<Mode: OutputMode> super::EventWriter<CommonSchemaOutput> for Provider<Mode>
                     chrono::DateTime::to_rfc3339(&chrono::DateTime::<chrono::Utc>::from(timestamp));
                 eb.add_str8("time", time, OutType::Utf8, 0);
 
-                if current_span != 0 {
+                // Use OTel context if available, otherwise fall back to local span ID
+                if let Some((trace_id, span_id)) = otel_context {
                     eb.add_struct("ext_dt", 2, 0);
                     {
-                        let span_id = unsafe {
-                            let mut span_id = MaybeUninit::<[u8; 16]>::uninit();
-                            let mut cur = Cursor::new((*span_id.as_mut_ptr()).as_mut_slice());
-                            write!(&mut cur, "{:16x}", current_span).expect("!write");
-                            span_id.assume_init()
-                        };
-
-                        eb.add_str8("traceId", "", OutType::Utf8, 0); // TODO
+                        eb.add_str8("traceId", trace_id, OutType::Utf8, 0);
                         eb.add_str8("spanId", span_id, OutType::Utf8, 0);
+                    }
+                } else if current_span != 0 {
+                    eb.add_struct("ext_dt", 2, 0);
+                    {
+                        let mut span_id_buf = [0u8; 16];
+                        let _ = std::io::Write::write_fmt(
+                            &mut span_id_buf.as_mut_slice(),
+                            format_args!("{:016x}", current_span),
+                        );
+
+                        eb.add_str8("traceId", [0u8; 32], OutType::Utf8, 0);
+                        eb.add_str8("spanId", span_id_buf, OutType::Utf8, 0);
                     }
                 }
             }

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -170,5 +170,6 @@ pub trait EventWriter<OutMode: OutputMode> {
         keyword: u64,
         event_tag: u32,
         event: &tracing::Event<'_>,
+        otel_context: Option<([u8; 32], [u8; 16])>, // (trace_id, span_id) when opentelemetry feature is enabled
     );
 }

--- a/src/native/noop.rs
+++ b/src/native/noop.rs
@@ -86,6 +86,7 @@ impl<OutMode: OutputMode> crate::native::EventWriter<OutMode> for Provider<OutMo
         _keyword: u64,
         _event_tag: u32,
         _event: &tracing::Event<'_>,
+        _otel_context: Option<([u8; 32], [u8; 16])>,
     ) {
     }
 }

--- a/src/native/user_events.rs
+++ b/src/native/user_events.rs
@@ -331,6 +331,7 @@ impl<Mode: OutputMode> super::EventWriter<NormalOutput> for Provider<Mode> {
         keyword: u64,
         event_tag: u32,
         event: &tracing::Event<'_>,
+        _otel_context: Option<([u8; 32], [u8; 16])>,
     ) {
         let es = if let Some(es) = self.find_set(Self::map_level(level), keyword) {
             es
@@ -454,11 +455,33 @@ impl<Mode: OutputMode> super::EventWriter<CommonSchemaOutput> for Provider<Mode>
     {
         let span_name = span.name();
 
-        let span_id = unsafe {
-            let mut span_id = MaybeUninit::<[u8; 16]>::uninit();
-            let mut cur = Cursor::new((*span_id.as_mut_ptr()).as_mut_slice());
-            write!(&mut cur, "{:16x}", span.id().into_u64()).expect("!write");
-            span_id.assume_init()
+        // Extract trace_id and span_id - prefer OpenTelemetry context when available
+        #[cfg(feature = "opentelemetry")]
+        let (trace_id, span_id) = {
+            let otel_ctx = crate::otel::extract_otel_context(span);
+            if otel_ctx.is_valid {
+                (otel_ctx.trace_id, otel_ctx.span_id)
+            } else {
+                // Fall back to local tracing span ID
+                let mut span_id_buf = [0u8; 16];
+                let mut trace_id_buf = [0u8; 32];
+                let _ = std::io::Write::write_fmt(
+                    &mut span_id_buf.as_mut_slice(),
+                    format_args!("{:016x}", span.id().into_u64()),
+                );
+                (trace_id_buf, span_id_buf)
+            }
+        };
+
+        #[cfg(not(feature = "opentelemetry"))]
+        let (trace_id, span_id) = {
+            let mut span_id_buf = [0u8; 16];
+            let trace_id_buf = [0u8; 32];
+            let _ = std::io::Write::write_fmt(
+                &mut span_id_buf.as_mut_slice(),
+                format_args!("{:016x}", span.id().into_u64()),
+            );
+            (trace_id_buf, span_id_buf)
         };
 
         let es = if let Some(es) = self.find_set(Self::map_level(level), keyword) {
@@ -487,7 +510,7 @@ impl<Mode: OutputMode> super::EventWriter<CommonSchemaOutput> for Provider<Mode>
 
                 eb.add_struct("ext_dt", 2, 0);
                 {
-                    eb.add_str("traceId", "", FieldFormat::Default, 0); // TODO
+                    eb.add_str("traceId", trace_id, FieldFormat::Default, 0);
                     eb.add_str("spanId", span_id, FieldFormat::Default, 0);
                 }
             }
@@ -511,11 +534,30 @@ impl<Mode: OutputMode> super::EventWriter<CommonSchemaOutput> for Provider<Mode>
                 eb.add_str("_typeName", "Span", FieldFormat::Default, 0);
 
                 if let Some(parent) = span_parent {
-                    let parent_span_id = unsafe {
-                        let mut span_id = MaybeUninit::<[u8; 16]>::uninit();
-                        let mut cur = Cursor::new((*span_id.as_mut_ptr()).as_mut_slice());
-                        write!(&mut cur, "{:16x}", parent.id().into_u64()).expect("!write");
-                        span_id.assume_init()
+                    // Extract parent span_id - prefer OpenTelemetry context when available
+                    #[cfg(feature = "opentelemetry")]
+                    let parent_span_id = {
+                        let otel_ctx = crate::otel::extract_otel_context(&parent);
+                        if otel_ctx.is_valid {
+                            otel_ctx.span_id
+                        } else {
+                            let mut buf = [0u8; 16];
+                            let _ = std::io::Write::write_fmt(
+                                &mut buf.as_mut_slice(),
+                                format_args!("{:016x}", parent.id().into_u64()),
+                            );
+                            buf
+                        }
+                    };
+
+                    #[cfg(not(feature = "opentelemetry"))]
+                    let parent_span_id = {
+                        let mut buf = [0u8; 16];
+                        let _ = std::io::Write::write_fmt(
+                            &mut buf.as_mut_slice(),
+                            format_args!("{:016x}", parent.id().into_u64()),
+                        );
+                        buf
                     };
 
                     eb.add_str("parentId", parent_span_id, FieldFormat::Default, 0);
@@ -564,6 +606,7 @@ impl<Mode: OutputMode> super::EventWriter<CommonSchemaOutput> for Provider<Mode>
         keyword: u64,
         event_tag: u32,
         event: &tracing::Event<'_>,
+        otel_context: Option<([u8; 32], [u8; 16])>,
     ) {
         let es = if let Some(es) = self.find_set(Self::map_level(level), keyword) {
             es
@@ -584,7 +627,7 @@ impl<Mode: OutputMode> super::EventWriter<CommonSchemaOutput> for Provider<Mode>
             eb.add_value("__csver__", 0x0401, FieldFormat::SignedInt, 0);
             eb.add_struct(
                 "PartA",
-                1 + if current_span != 0 { 1 } else { 0 }, /* + exts.len() as u8*/
+                1 + if current_span != 0 || otel_context.is_some() { 1 } else { 0 }, /* + exts.len() as u8*/
                 0,
             );
             {
@@ -592,18 +635,24 @@ impl<Mode: OutputMode> super::EventWriter<CommonSchemaOutput> for Provider<Mode>
                     chrono::DateTime::to_rfc3339(&chrono::DateTime::<chrono::Utc>::from(timestamp));
                 eb.add_str("time", time, FieldFormat::Default, 0);
 
-                if current_span != 0 {
+                // Use OTel context if available, otherwise fall back to local span ID
+                if let Some((trace_id, span_id)) = otel_context {
                     eb.add_struct("ext_dt", 2, 0);
                     {
-                        let span_id = unsafe {
-                            let mut span_id = MaybeUninit::<[u8; 16]>::uninit();
-                            let mut cur = Cursor::new((*span_id.as_mut_ptr()).as_mut_slice());
-                            write!(&mut cur, "{:16x}", current_span).expect("!write");
-                            span_id.assume_init()
-                        };
-
-                        eb.add_str("traceId", "", FieldFormat::Default, 0); // TODO
+                        eb.add_str("traceId", trace_id, FieldFormat::Default, 0);
                         eb.add_str("spanId", span_id, FieldFormat::Default, 0);
+                    }
+                } else if current_span != 0 {
+                    eb.add_struct("ext_dt", 2, 0);
+                    {
+                        let mut span_id_buf = [0u8; 16];
+                        let _ = std::io::Write::write_fmt(
+                            &mut span_id_buf.as_mut_slice(),
+                            format_args!("{:016x}", current_span),
+                        );
+
+                        eb.add_str("traceId", [0u8; 32], FieldFormat::Default, 0);
+                        eb.add_str("spanId", span_id_buf, FieldFormat::Default, 0);
                     }
                 }
             }

--- a/src/otel.rs
+++ b/src/otel.rs
@@ -1,0 +1,104 @@
+//! OpenTelemetry integration helpers.
+//!
+//! This module provides utilities for extracting OpenTelemetry trace context
+//! from tracing span extensions when the `opentelemetry` feature is enabled.
+
+use tracing_subscriber::registry::LookupSpan;
+
+/// Represents OpenTelemetry trace context extracted from a span.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct OtelContext {
+    /// The trace ID as a 32-character lowercase hex string.
+    pub trace_id: [u8; 32],
+    /// The span ID as a 16-character lowercase hex string.
+    pub span_id: [u8; 16],
+    /// Whether valid OTel context was found.
+    pub is_valid: bool,
+}
+
+impl OtelContext {
+    /// Create an invalid/empty OTel context
+    pub const fn empty() -> Self {
+        Self {
+            trace_id: [0u8; 32],
+            span_id: [0u8; 16],
+            is_valid: false,
+        }
+    }
+}
+
+/// Extract OpenTelemetry context from a span's extensions.
+///
+/// This function attempts to read the `OtelData` extension that is set by
+/// `tracing-opentelemetry` and extract the trace_id and span_id from it.
+///
+/// Returns an `OtelContext` with `is_valid = true` if OTel context was found,
+/// otherwise returns a default context with `is_valid = false`.
+pub fn extract_otel_context<'a, R>(span: &tracing_subscriber::registry::SpanRef<'a, R>) -> OtelContext
+where
+    R: LookupSpan<'a>,
+{
+    let extensions = span.extensions();
+    if let Some(otel_data) = extensions.get::<tracing_opentelemetry::OtelData>() {
+        // In tracing-opentelemetry 0.32+, OtelData provides trace_id() and span_id() methods
+        let trace_id = otel_data.trace_id();
+        let span_id = otel_data.span_id();
+
+        if let (Some(tid), Some(sid)) = (trace_id, span_id) {
+            return format_otel_context(tid, sid);
+        }
+    }
+
+    OtelContext::empty()
+}
+
+/// Format trace_id and span_id into an OtelContext with lowercase hex string
+/// bytes.
+fn format_otel_context(
+    tid: opentelemetry::trace::TraceId,
+    sid: opentelemetry::trace::SpanId,
+) -> OtelContext {
+    let mut ctx = OtelContext {
+        trace_id: [0u8; 32],
+        span_id: [0u8; 16],
+        is_valid: true,
+    };
+
+    // Format trace_id as 32-character lowercase hex
+    let tid_bytes = tid.to_bytes();
+    for (i, byte) in tid_bytes.iter().enumerate() {
+        let hex = format!("{:02x}", byte);
+        ctx.trace_id[i * 2] = hex.as_bytes()[0];
+        ctx.trace_id[i * 2 + 1] = hex.as_bytes()[1];
+    }
+
+    // Format span_id as 16-character lowercase hex
+    let sid_bytes = sid.to_bytes();
+    for (i, byte) in sid_bytes.iter().enumerate() {
+        let hex = format!("{:02x}", byte);
+        ctx.span_id[i * 2] = hex.as_bytes()[0];
+        ctx.span_id[i * 2 + 1] = hex.as_bytes()[1];
+    }
+
+    ctx
+}
+
+/// Extract OpenTelemetry context from a parent span's extensions.
+///
+/// Similar to `extract_otel_context` but takes an optional span reference
+/// and returns None if the span is None or has no OTel context.
+pub fn extract_parent_otel_context<'a, R>(
+    parent: Option<tracing_subscriber::registry::SpanRef<'a, R>>,
+) -> Option<OtelContext>
+where
+    R: LookupSpan<'a>,
+{
+    parent.map(|p| {
+        let ctx = extract_otel_context(&p);
+        if ctx.is_valid {
+            Some(ctx)
+        } else {
+            None
+        }
+    }).flatten()
+}


### PR DESCRIPTION
Adds an optional feature to the etw crate that supports fetching the opentelemetry trace_id and span_id from the span context when present. Otherwise it uses the tracing crate trace_id as a fallback to maintain backward compatibility if the feature is not enabled.